### PR TITLE
Misspelled the module needed in app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Angular JS.
 3. include the files in your app
 	1. `src/regthreesixty.js`
 	2. `src/regthreesixty.css`
-4. include the module in angular (i.e. in `app.js`) - `reg.threeSixty`
+4. include the module in angular (i.e. in `app.js`) - `reg.threesixty`
 
 
 ## Basic usage


### PR DESCRIPTION
In your regthreesixty.js file, your module is named `reg.threesixty`, but your README.md says `reg.threeSixty`.